### PR TITLE
Update API to match 0.11.12 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var result = spawnSync('node',
 // Note, status code will always equal 0 if using busy waiting fallback
 if (result.statusCode !== 0) {
   process.stderr.write(result.stderr);
-  process.exit(result.statusCode);
+  process.exit(result.status);
 } else {
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function spawn(cmd, args, options) {
   }
   var exitCode = invoke(cmd);
   var res = {
-    exitCode: exitCode,
+    status: exitCode,
     stdout: fs.readFileSync(stdout),
     stderr: fs.readFileSync(stderr)
   };


### PR DESCRIPTION
According to the API docs, the exit code should be reported in `status`.

http://nodejs.org/docs/v0.11.12/api/child_process.html#child_process_child_process_spawnsync_command_args_options
