### PR TITLE
Add support for Node.js < 0.10

### DIFF
--- a/lib/spawn-sync.js
+++ b/lib/spawn-sync.js
@@ -2,7 +2,7 @@
 
 var path = require('path');
 var fs = require('fs');
-var os = require('os');
+var tmpdir = require('os').tmpdir || require('os-shim').tmpdir;
 var cp = require('child_process');
 var sleep;
 var JSON = require('./json-buffer');
@@ -15,7 +15,7 @@ try {
   sleep = function () {};
 }
 
-var temp = path.normalize(path.join(os.tmpdir(), 'spawn-sync'));
+var temp = path.normalize(path.join(tmpdir(), 'spawn-sync'));
 
 function randomFileName(name) {
   function randomHash(count) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Prollyfill for child_process.spawnSync",
   "keywords": [],
   "dependencies": {
-    "concat-stream": "^1.4.7"
+    "concat-stream": "^1.4.7",
+    "os-shim": "^0.1.2"
   },
   "devDependencies": {
     "try-thread-sleep": "^1.0.0"


### PR DESCRIPTION
Greetings,

Recently, I attempted to use spawn-sync with Node.js 0.8.9 and found that it was failing since os.tmpdir did not exist.  This pull request adds the os-shim module as a dependency and will use that module if it can not find os.tmpdir.  If you are not interested in this change, it would be nice to have 'engine' included in the package.json so that the npm install would fail.  Thanks for reviewing this and for the module itself.