### PR TITLE
use $npm_execpath to find npm executable

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -31,7 +31,7 @@ if (cp.spawnSync || __dirname.indexOf('node_modules') === -1) {
 }
 if (REQUIRES_UPDATE && __dirname.indexOf('node_modules') !== -1) {
   fs.writeFileSync(__dirname + '/package.json', JSON.stringify(pkg, null, '  '));
-  cp.exec('npm install --production', {
+  cp.exec((process.env.npm_execpath || 'npm') + 'install --production', {
     cwd: __dirname
   }, function (err) {
     if (err) {


### PR DESCRIPTION
Fixes #17

Falls back on `'npm'` if for some reason `process.env.npm_execpath` isn't available.