### PR TITLE
make postinstall more robust

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -2,32 +2,17 @@
 
 var fs = require('fs');
 var cp = require('child_process');
-var assert = require('assert');
-
-var partialDependencies = {
-  "concat-stream": "^1.4.7",
-  "os-shim": "^0.1.2"
-};
-var fullDependencies = {
-  "concat-stream": "^1.4.7",
-  "os-shim": "^0.1.2",
-  "try-thread-sleep": "^1.0.0"
-};
 
 var REQUIRES_UPDATE = false;
 var pkg = JSON.parse(fs.readFileSync(__dirname + '/package.json', 'utf8'));
 if (cp.spawnSync || __dirname.indexOf('node_modules') === -1) {
-  try {
-    assert.deepEqual(pkg.dependencies, partialDependencies);
-  } catch (ex) {
-    pkg.dependencies = partialDependencies;
+  if(pkg.dependencies['try-thread-sleep']){
+    delete pkg.dependencies['try-thread-sleep'];
     REQUIRES_UPDATE = true;
   }
 } else {
-  try {
-    assert.deepEqual(pkg.dependencies, fullDependencies);
-  } catch (ex) {
-    pkg.dependencies = fullDependencies;
+  if(!pkg.dependencies['try-thread-sleep']){
+    pkg.dependencies['try-thread-sleep'] = "^1.0.0";
     REQUIRES_UPDATE = true;
   }
 }


### PR DESCRIPTION
@ForbesLindesay 

Makes the postinstall script more robust by not having to restate all the dependencies in `package.json` but just deal with `try-thread-sleep`.