### PR TITLE
windows npm_execpath

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -33,7 +33,7 @@ if (cp.spawnSync || __dirname.indexOf('node_modules') === -1) {
 }
 if (REQUIRES_UPDATE && __dirname.indexOf('node_modules') !== -1) {
   fs.writeFileSync(__dirname + '/package.json', JSON.stringify(pkg, null, '  '));
-  cp.exec((process.env.npm_execpath ? ('"' + process.env.npm_execpath + '"') : 'npm') + ' install --production', {
+  cp.exec((process.env.npm_execpath ? ('"' + process.argv[0] + '" "' + process.env.npm_execpath + '"') : 'npm') + ' install --production', {
     cwd: __dirname
   }, function (err) {
     if (err) {


### PR DESCRIPTION
This should make sure that the correct node executable is being used to run npm.

I don't have access to a Windows machine at the moment. Could someone verify that this fixes #22 ?