### PR TITLE
Fix usage with stdio 'ignore'.

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -22,10 +22,10 @@ var options = (args[2] && typeof args[2] === 'object') ?
 
 var complete = false;
 var stdout, stderr;
-child.stdout.pipe(concat(function (buf) {
+child.stdout && child.stdout.pipe(concat(function (buf) {
   stdout = buf.length ? buf : new Buffer(0);
 }));
-child.stderr.pipe(concat(function (buf) {
+child.stderr && child.stderr.pipe(concat(function (buf) {
   stderr = buf.length ? buf : new Buffer(0);
 }));
 child.on('error', function (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,25 @@ function testSpawn(spawn) {
   assert(result.stdout.toString() === '');
   assert(result.stderr.toString() === '');
 
+  var result = spawn("node", [__dirname + '/test-empty.js'], { stdio: ['pipe', 'ignore', 'pipe']});
+  assert(result.status === 0);
+  assert(Buffer.isBuffer(result.stderr));
+  assert(result.stdout == null);
+  assert(result.stderr.toString() === '');
+
+  var result = spawn("node", [__dirname + '/test-empty.js'], { stdio: ['pipe', 'pipe', 'ignore']});
+  assert(result.status === 0);
+  assert(Buffer.isBuffer(result.stdout));
+  assert(result.stdout.toString() === '');
+  assert(result.stderr == null);
+
+  var result = spawn("node", [__dirname + '/test-empty.js'], { stdio: ['ignore', 'pipe', 'pipe']});
+  assert(result.status === 0);
+  assert(Buffer.isBuffer(result.stdout));
+  assert(Buffer.isBuffer(result.stderr));
+  assert(result.stdout.toString() === '');
+  assert(result.stderr.toString() === '');
+
   // This suprisingly fails for the official API
   /*
   var start = Date.now();


### PR DESCRIPTION
This fixes usages with `ignore`.

A question, if I pass a `stream` as the stdio[1] or stdio[2] it won't work out right?