### PR TITLE
Use process.execPath to invoke node

### DIFF
--- a/lib/spawn-sync.js
+++ b/lib/spawn-sync.js
@@ -82,7 +82,7 @@ function spawnSyncFallback(cmd, commandArgs, options) {
   unlink(output);
 
   fs.writeFileSync(input, JSON.stringify(args));
-  invoke('node "' + worker + '" "' + input + '" "' + output + '"');
+  invoke(process.execPath + ' "' + worker + '" "' + input + '" "' + output + '"');
   var res = JSON.parse(fs.readFileSync(output, 'utf8'));
   tryUnlink(input);tryUnlink(output);
   return res;


### PR DESCRIPTION
If the new shell created by the invocation doesn't have `node` in the `PATH` the command will fail. This way, the same Node.js executable will be used for the worker regardless of `nvm` and other setups.