### PR TITLE
Fix process.execPath's with spaces.

### DIFF
--- a/lib/spawn-sync.js
+++ b/lib/spawn-sync.js
@@ -82,7 +82,7 @@ function spawnSyncFallback(cmd, commandArgs, options) {
   unlink(output);
 
   fs.writeFileSync(input, JSON.stringify(args));
-  invoke(process.execPath + ' "' + worker + '" "' + input + '" "' + output + '"');
+  invoke('"' + process.execPath + '" "' + worker + '" "' + input + '" "' + output + '"');
   var res = JSON.parse(fs.readFileSync(output, 'utf8'));
   tryUnlink(input);tryUnlink(output);
   return res;


### PR DESCRIPTION
#35 introduced a bug for people that have node.exe inside directories with spaces, e.g. `c:\Program Files`

This PR fixes that issue